### PR TITLE
The required dependency is tensorboard-pytorch and not tensorboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ python 2.7
 Pytorch
 
 In addition, please add the project folder to PYTHONPATH and `pip install` the following packages:
-- `tensorboard`
+- `tensorboard-pytorch`
 - `python-dateutil`
 - `easydict`
 - `pandas`


### PR DESCRIPTION
The dependency while setting up StackGan++ is tensorboard-pytorch and not tensorboard.

There is no FileWriter name in the original tensorboard. Hence 
```from tensorboard import FileWriter``` in trainer.py will throw an error.

I got past the error by using tensorboard-pytorch